### PR TITLE
Rename new admins rolebinding

### DIFF
--- a/rbac/admins/cluster-admins.clusterrolebinding.yaml
+++ b/rbac/admins/cluster-admins.clusterrolebinding.yaml
@@ -7,11 +7,11 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
     name: shared-infrastructure-admins
   - kind: ServiceAccount
-    apiGroup: rbac.authorization.k8s.io
-    name: 'system:serviceaccount:cicd:gurnben'
+    name: gurnben
+    namespace: cicd
   - kind: ServiceAccount
-    apiGroup: rbac.authorization.k8s.io
-    name: 'system:serviceaccount:managedservices:gurnben'
+    name: gurnben
+    namespace: managed-services
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/admins/cluster-admins.clusterrolebinding.yaml
+++ b/rbac/admins/cluster-admins.clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-admins
+  name: collective-cluster-admins
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary of Changes

Turns out, OpenShift has a cluster-admins ClusterRoleBinding already - so lets rename this to avoid collision.  