### PR TITLE
Add a namespace, managedclusterset, and rolebindings for the ACS team

### DIFF
--- a/rbac/clusterdeployments.view/clusterdeployments.view.clusterrolebinding.yaml
+++ b/rbac/clusterdeployments.view/clusterdeployments.view.clusterrolebinding.yaml
@@ -126,6 +126,12 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'system:serviceaccounts:aoc-sre'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: acm
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acs'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/acs/managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/acs/managedclusterset.rolebinding.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: acs-managedclusterset-admin
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: acm
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acs'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:managedclusterset:admin:acs

--- a/rbac/managedclustersets/acs/managedclusterset.yaml
+++ b/rbac/managedclustersets/acs/managedclusterset.yaml
@@ -1,0 +1,4 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: ManagedClusterSet
+metadata:
+  name: acs

--- a/rbac/namespaces/acs/namespace.yaml
+++ b/rbac/namespaces/acs/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acs

--- a/rbac/namespaces/acs/rolebinding.yaml
+++ b/rbac/namespaces/acs/rolebinding.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: acs-namespace-access
+  namespace: acs
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: acm
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acs'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/rbac/open-cluster-management.view/tenants.ocm-view.rolebinding.yaml
+++ b/rbac/open-cluster-management.view/tenants.ocm-view.rolebinding.yaml
@@ -127,6 +127,12 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'system:serviceaccounts:aoc-sre'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: acm
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acs'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/project.create/tenants.project-create.rolebinding.yaml
+++ b/rbac/project.create/tenants.project-create.rolebinding.yaml
@@ -127,6 +127,12 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'system:serviceaccounts:aoc-sre'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: acm
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acs'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Summary of Changes

This PR creates a new `acs` namespace and gives the ACS team (under their RBAC group "acm", synced from the stackrox GitHub Organization) access to said namespace and regular squad artifacts.  