### PR TITLE
Add observability GitHub team to search resources

### DIFF
--- a/rbac/managedclustersets/acm-observability-usa/acm-observability-usa.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/acm-observability-usa/acm-observability-usa.managedclusterset.rolebinding.yaml
@@ -5,6 +5,12 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
+    name: 'Observability'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'Observability-Admin'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
     name: 'Search'
   - kind: Group
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary of Changes

The Search team and Observability teams share resources, so they would like to share RBAC access!  This PR adds ManagedClusterSet permissions!