### PR TITLE
add clusterimageset for ocp 4.11 fc3

### DIFF
--- a/cluster-artifacts/global/clusterimagesets/img4.11.0-fc.3-x86_64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.11.0-fc.3-x86_64.yaml
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img4.11.0-fc3-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.11.0-fc.3-x86_64


### PR DESCRIPTION
Signed-off-by: David Huynh <dhuynh@redhat.com>
Adding clusterimageset to collective for img4.11.0-fc.3-x86_64.yaml