### PR TITLE
The hibernator Service Account in app, seems to be missing the required access to list and patch all clusterDeployments and Events

### DIFF
--- a/rbac/hibernator/clusterrole-clusterrolebinding.yaml
+++ b/rbac/hibernator/clusterrole-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hibernator-curator
+rules:
+- apiGroups: ["hive.openshift.io"]
+  resources: ["clusterdeployments"]
+  verbs: ["get", "list", "patch"]
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: hibernator-curator
+subjects:
+- kind: ServiceAccount
+  name: hibernator
+  namespace: app
+roleRef:
+  kind: ClusterRole
+  name: hibernator-curator
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This new RBAC will defines the ClusterRole and the ClusterRoleBinding so that we start receiving events as well (previously were giving a permission error).