### PR TITLE
Fix the eventing errors, by granting Hibernator SA the ClusterRole to…

### DIFF
--- a/rbac/events.create.update.view/events.create.update.view.clusterrolebinding.yaml
+++ b/rbac/events.create.update.view/events.create.update.view.clusterrolebinding.yaml
@@ -1,0 +1,27 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: events-create-update-view-hibernator
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acm-observability-usa'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:cluster-lifecycle'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:console-squad'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:far-edge'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:managed-services'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:obs-int-analytics'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: events-create-update-view-hibernator

--- a/rbac/events.create.update.view/events.create.update.view.yaml
+++ b/rbac/events.create.update.view/events.create.update.view.yaml
@@ -1,0 +1,8 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: events-create-update-view-hibernator
+rules:
+    - apiGroups: ["events.k8s.io"]
+      resources: ["events"]
+      verbs: ["create", "get", "update"]

--- a/rbac/hibernator/HIBERNATION-CRONJOB.md
+++ b/rbac/hibernator/HIBERNATION-CRONJOB.md
@@ -1,5 +1,7 @@
 # How RBAC works for the Hibernator-cronjobs
 
-Access control is obtained by leveraging the ManagedClusterSets. When a cluster is created with a ClusterClaim, which includes a ManagedClusterSet label, a ClusterRole is created and bound to `system:serviceaccounts:NAMESPACE` where NAMESPACE is where the ClusterClaim was created.  This allows the hiberantor service account in the NAMESPACE to modify the hibernation state of the ClusterDeployment in question.
+1. Access control is obtained by leveraging the ManagedClusterSets. When a cluster is created with a ClusterClaim, which includes a ManagedClusterSet label, a ClusterRole is created and bound to `system:serviceaccounts:NAMESPACE` where NAMESPACE is where the ClusterClaim was created.  This allows the hiberantor service account in the NAMESPACE to modify the hibernation state of the ClusterDeployment in question.
 
-You must also add the `system:serviceacounts:NAMESPCE` subject to the `/rbac/clusterdeployments.view/clusterdeployments.view/clusterrolebinding.yaml`
+2. You must add the `system:serviceacounts:NAMESPCE` subject to the `/rbac/clusterdeployments.view/clusterdeployments.view/clusterrolebinding.yaml`
+
+3. You must add the `system_serviceaccounts:NAMESPACE` subject to the `/rbac/events.create.update.view/events.create.update.view.yaml`


### PR DESCRIPTION
… create, update, get events.

Currently all our cronjobs log errors that they can not create kube events when trying to hibernate a cluster.

This function should allow us to update these events.