### PR TITLE
Add next OCP version RC and clean up old pre-release images

### DIFF
--- a/cluster-artifacts/global/clusterimagesets/img4.10.0-fc.4-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.10.0-fc.4-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.10.0-fc.4-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.0-fc.4-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.10.0-rc.1-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.10.0-rc.1-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.10.0-rc.1-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.10.0-rc.2-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.10.0-rc.2-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.10.0-rc.2-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.0-rc.2-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.10.0-rc.4-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.10.0-rc.4-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.10.0-rc.4-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.0-rc.4-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.10.13-multi.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.10.13-multi.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.10.13-multi
-spec:
-  releaseImage: 'quay.io/gurnben/imagesets:4.10.13'

--- a/cluster-artifacts/global/clusterimagesets/img4.10.6-x86_64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.10.6-x86_64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.10.6-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.6-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.10.7-x86_64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.10.7-x86_64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.10.7-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.7-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.11.0-0.nightly-multi-2022-04-19-151226-x86_64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.11.0-0.nightly-multi-2022-04-19-151226-x86_64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.11.0-0.nightly-multi-2022-04-19-151226-x86-64
-spec:
-  releaseImage: 'quay.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-04-19-151226-x86_64'

--- a/cluster-artifacts/global/clusterimagesets/img4.11.0-fc.2-x86_64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.11.0-fc.2-x86_64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.11.0-fc2-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.11.0-fc.2-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.11.0-fc.3-x86_64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.11.0-fc.3-x86_64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.11.0-fc3-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.11.0-fc.3-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.12.0-0.nightly-2022-09-12-152748-x86_64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.12.0-0.nightly-2022-09-12-152748-x86_64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.12.0-0.nightly-2022-09-12-152748
-spec:
-  releaseImage: 'registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-09-12-152748'

--- a/cluster-artifacts/global/clusterimagesets/img4.13.0-ec.1-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.13.0-ec.1-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.13.0-ec.1-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.13.0-ec.1-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.13.0-ec.2-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.13.0-ec.2-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.13.0-ec.2-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.13.0-ec.2-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.13.0-ec.3-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.13.0-ec.3-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.13.0-ec.3-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.13.0-ec.3-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.13.0-rc.2-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.13.0-rc.2-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.13.0-rc.2-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.13.0-rc.2-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.16.0-rc.2-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.16.0-rc.2-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.16.0-rc.2-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.16.0-rc.2-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.17.0-rc.2-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.17.0-rc.2-x86-64.yaml
@@ -1,6 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: img4.17.0-rc.2-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.2-multi-x86_64

--- a/cluster-artifacts/global/clusterimagesets/img4.18.0-rc.8-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.18.0-rc.8-x86-64.yaml
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img4.18.0-rc.8-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.18.0-rc.8-x86_64


### PR DESCRIPTION
Adds 4.18.0-rc.8 to collective; removes all other pre-release images for previous versions