### PR TITLE
Add a 4.16 image to collective

### DIFF
--- a/cluster-artifacts/global/clusterimagesets/img4.16.46-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.16.46-x86-64.yaml
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img4.16.46-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.16.46-x86_64


### PR DESCRIPTION
Seems all the 4.16 ClusterImageSets have been removed