### PR TITLE
Add quay.io/openshift-release-dev/ocp-release:5.0.0-ec.0-x86_64

### DIFF
--- a/cluster-artifacts/global/clusterimagesets/img5.0.0-ec.0-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img5.0.0-ec.0-x86-64.yaml
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img5.0.0-ec.0-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:5.0.0-ec.0-x86_64


### PR DESCRIPTION
## Summary
- Adds ClusterImageSet for OCP 5.0.0-ec.0 x86_64 release

## Test plan
- [ ] Verify the ClusterImageSet is created successfully
- [ ] Verify the release image is accessible from quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)