### PR TITLE
Add quay.io/openshift-release-dev/ocp-release:4.22.0-rc.1-x86_64

### DIFF
--- a/cluster-artifacts/global/clusterimagesets/img4.22.0-rc.1-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.22.0-rc.1-x86-64.yaml
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img4.22.0-rc.1-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-rc.1-x86_64


### PR DESCRIPTION
## Summary
- Adds a new ClusterImageSet for OCP 4.22.0-rc.1 x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)