### PR TITLE
Add quay.io/openshift-release-dev/ocp-release:4.22.0-rc.5-x86_64

### DIFF
--- a/cluster-artifacts/global/clusterimagesets/img4.22.0-rc.5-x86-64.yaml
+++ b/cluster-artifacts/global/clusterimagesets/img4.22.0-rc.5-x86-64.yaml
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img4.22.0-rc.5-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-rc.5-x86_64


### PR DESCRIPTION
Adds a new ClusterImageSet for OCP 4.22.0-rc.5 x86_64